### PR TITLE
docs: add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: 🐛 Bug Report
+description: Report a reproducible bug or error.
+title: "bug: "
+labels: ["bug"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below carefully.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 📝 Description
+      description: Clearly describe the bug.
+      placeholder: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 🚀 Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 📸 Screenshots
+      description: Add screenshots or screen recordings if applicable.
+      placeholder: Drag and drop images here
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 💻 Environment
+      description: Please provide environment details.
+      placeholder: |
+        OS: Windows / macOS / Linux
+        Browser: Chrome / Firefox / Edge
+    validations:
+      required: true
+
+  - type: textarea
+    id: possible_fix
+    attributes:
+      label: 💡 Possible Fix
+      description: Suggest a fix if you have one.
+      placeholder: Optional


### PR DESCRIPTION
This PR adds a structured Bug Report issue template to improve the quality and consistency of bug submissions.
The template guides contributors to provide clear descriptions, reproducible steps, screenshots, environment details, and possible fixes. This will help maintainers debug issues faster and reduce incomplete or low-quality bug reports.
This change is documentation-only and does not affect application logic.

fixes #24 
Screenshots:
N/A – documentation-only change
