### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+CONTRIBUTING TO COLLEGE MEDIA 🎓 - CONTAIN LISTED BELOW !!
+Thank you for your interest in contributing! To maintain code quality and project integrity, please follow these guidelines.
+
+🛠️ DEVELOPMENT STANDARDS
+Framework: Built using React 19.
+
+Styling: Use Tailwind CSS for all new components.
+
+Naming Conventions:
+
+PascalCase for React components (e.g., PostCard.jsx).
+
+camelCase for variables and functions.
+
+Linting: You must run npm run lint and fix all warnings before committing.
+
+🚦 WORKFLOW
+Fork & Clone: Fork the repository and clone it to your local machine.
+Branching: Create a descriptive feature branch: git checkout -b feature/your-feature-name.
+Environment: Copy .env.example to .env before starting development.
+Pull Request: Submit your PR against the main branch using the required PR template.
+
+📝 COMMIT MESSAGES
+We follow the type(scope): subject format:
+
+feat: A new feature
+fix: A bug fix
+docs: Documentation changes
+refactor: Code changes that neither fix a bug nor add a feature
+
+🚫 COMMUNITY GUIDELINES & MORALE
+No Negative Comments: Comments on assigned issues that decrease morale or discourage other contributors are strictly prohibited.
+Respect Assignment: Wait for an issue to be officially assigned to you before starting work or submitting a PR. Unsolicited PRs for unassigned issues will be closed.
+
+📸 VISUAL REQUIREMENTS (MANDATORY)
+Screenshots of Changes: You MUST provide screenshots or GIFs of the new changes in your PR.
+Screenshots of the Area to be Changed: You MUST provide screenshots of the current state when opening an Issue.
+
+⏱️ TIME CONSTRAINTS & DISQUALIFICATION
+Assignment Window: Once assigned, work must begin immediately.
+Max Limit: Contributors can ask for Maximum 3 Issues in a day, More only if the assigned Ones are done
+Standard Deadline: Tasks should ideally be completed within 30 minutes to 48 hours.
+Maximum Grace Period: If no progress is shown after 72 hours, the issue will be unassigned and given to another contributor.
+Code Quality Disqualification: Submitting a PR that fails the build, ignores linting rules, or lacks the mandatory screenshots will result in immediate disqualification from the issue.
+Duplicate Submissions: Submitting a PR for an issue already assigned to someone else is grounds for a warning or ban from the project.
+Stale PRs: If a contributor fails to respond to requested changes within 24 hours, the PR may be closed.


### PR DESCRIPTION
This PR adds the complete CONTRIBUTING.md file with all guidelines
as specified by the maintainer, including development standards,
workflow, commit conventions, community rules, visual requirements,
and time constraints.

Fixes #31

Screenshots:
N/A (documentation-only change)