### PR TITLE
fix: make footer year dynamic

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,8 @@
 import React from 'react'
 
 const Footer = () => {
-  return (
+    const currentYear = new Date().getFullYear()
+    return (
 <footer className="bg-white border-t border-slate-100 pt-16 pb-8" role="contentinfo">
         <div className="max-w-7xl mx-auto px-6">
             <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-8 mb-12">
@@ -72,7 +73,7 @@ const Footer = () => {
             </div>
             
             <div className="flex flex-col md:flex-row items-center justify-between pt-8 border-t border-slate-100 gap-4">
-                <p className="text-xs text-slate-400">© 2026 UniHub Inc. All rights reserved.</p>
+                <p className="text-xs text-slate-400">© {currentYear} UniHub Inc. All rights reserved.</p>
                 <div className="flex gap-6" role="list" aria-label="Social media links">
                     <a 
                         href="#" 


### PR DESCRIPTION
## 📝 Description (Mandatory)
Replace the hardcoded footer year with a dynamic value so the site always displays the current year.

---

## 🛠️ PR Changes (Mandatory)
## 🗂 Files Changed
- **Footer.jsx (lines 1–200)**  
  Updated the footer implementation.

## ⚙️ Implementation Details
- Added a dynamic year constant:
  ```js
  const currentYear = new Date().getFullYear();


---

## 📸 Screenshots (Mandatory)
<img width="1835" height="314" alt="image" src="https://github.com/user-attachments/assets/27abff40-8d9b-4528-94ff-fe6533541c36" />


---

## 🔗 Related Issue
Fixes #77 

---

## ✅ Checklist (Mandatory)
- [x] I have followed the `type(scope): subject` commit naming convention
- [x] I have tested these changes on `localhost:5173`
- [x] I have run `npm run lint` and fixed warnings
- [x] My changes are responsive on both Mobile and Desktop
