### PR TITLE
feat(dashboard): instructor dashboard & course creator layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "react",
       "version": "0.0.0",
       "dependencies": {
+        "framer-motion": "^12.24.12",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.11.0"
@@ -2334,6 +2335,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.24.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.24.12.tgz",
+      "integrity": "sha512-W+tBOI1SDGNMH4D4mADY95qYd16Drke2Tj9zlGlwTGSCi6yy8wbMmPY1mvirfcTK8HBeuuCd2PflHdN/zbL4ew==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.24.11",
+        "motion-utils": "^12.24.10",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3003,6 +3031,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.24.11",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.24.11.tgz",
+      "integrity": "sha512-DlWOmsXMJrV8lzZyd+LKjG2CXULUs++bkq8GZ2Sr0R0RRhs30K2wtY+LKiTjhmJU3W61HK+rB0GLz6XmPvTA1A==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.24.10"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.24.10",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.24.10.tgz",
+      "integrity": "sha512-x5TFgkCIP4pPsRLpKoI86jv/q8t8FQOiM/0E8QKBzfMozWHfkKap2gA1hOki+B5g3IsBNpxbUnfOum1+dgvYww==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3856,6 +3899,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "framer-motion": "^12.24.12",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.11.0"

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,7 @@
+/* =========================
+   Utilities & Animations
+========================= */
+
 .scrollbar-hide::-webkit-scrollbar {
   display: none;
 }
@@ -5,42 +9,99 @@
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
+
 .border-gradient-to-r {
   background: linear-gradient(to right, #ec4899, #8b5cf6, #f97316);
   border: 2px solid transparent;
   background-clip: padding-box, border-box;
   background-origin: padding-box, border-box;
 }
+
 @keyframes bounce {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.2);
-  }
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.2); }
 }
 .animate-bounce {
   animation: bounce 0.5s ease-in-out;
 }
+
 @keyframes blob {
-  0%,
-  100% {
-    transform: translate(0, 0) scale(1);
-  }
-  33% {
-    transform: translate(30px, -50px) scale(1.1);
-  }
-  66% {
-    transform: translate(-20px, 20px) scale(0.9);
-  }
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  33% { transform: translate(30px, -50px) scale(1.1); }
+  66% { transform: translate(-20px, 20px) scale(0.9); }
 }
 .animate-blob {
   animation: blob 7s infinite;
 }
-.animation-delay-2000 {
-  animation-delay: 2s;
+
+.animation-delay-2000 { animation-delay: 2s; }
+.animation-delay-4000 { animation-delay: 4s; }
+
+/* =========================
+   Instructor Dashboard
+========================= */
+
+.dashboard {
+  max-width: 900px;
+  margin: auto;
+  padding: 2rem;
 }
-.animation-delay-4000 {
-  animation-delay: 4s;
+
+.course-form input,
+.course-form textarea {
+  width: 100%;
+  padding: 12px;
+  margin-bottom: 1rem;
+  border-radius: 8px;
+  border: none;
+}
+
+/* Upload */
+
+.upload-zone {
+  border: 2px dashed #7c7cff;
+  padding: 2rem;
+  text-align: center;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  transition: 0.3s;
+}
+
+.upload-zone.active {
+  background: rgba(124, 124, 255, 0.15);
+}
+
+/* Curriculum */
+
+.curriculum {
+  margin-bottom: 2rem;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+.lesson-item {
+  cursor: grab;
+}
+.lesson-item:active {
+  cursor: grabbing;
+}
+
+
+
+.lesson-dot {
+  width: 10px;
+  height: 10px;
+  background: #7c7cff;
+  border-radius: 50%;
+}
+
+/* Live Preview */
+
+.preview-card {
+  border: 1px solid rgba(124, 124, 255, 0.2);
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,13 @@
 import "./App.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { useState } from "react";
+
 import Home from "./pages/Home";
 import Landing from "./pages/Landing";
 import Messages from "./pages/Messages";
 import Profile from "./pages/Profile";
+import InstructorDashboard from "./pages/InstructorDashboard"; // new
+
 import Navbar from "./components/Navbar";
 import LeftSidebar from "./components/LeftSidebar";
 import RightSidebar from "./components/RightSidebar";
@@ -16,25 +19,43 @@ const App = () => {
   return (
     <Router>
       <Routes>
+        {/* Landing Page */}
         <Route path="/" element={<Landing />} />
-        <Route path="/home" element={
-          <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-orange-50">
-            <Navbar searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-              <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-                <LeftSidebar activeTab={activeTab} setActiveTab={setActiveTab} />
-                <div className="lg:col-span-2 space-y-6">
-                  <Routes>
-                    <Route path="/" element={<Home />} />
-                    <Route path="/messages" element={<Messages />} />
-                    <Route path="/profile" element={<Profile />} />
-                  </Routes>
+
+        {/* Instructor Dashboard (NEW) */}
+        <Route path="/instructor" element={<InstructorDashboard />} />
+
+        {/* Main App */}
+        <Route
+          path="/home"
+          element={
+            <div className="min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-orange-50">
+              <Navbar
+                searchQuery={searchQuery}
+                setSearchQuery={setSearchQuery}
+              />
+
+              <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
+                  <LeftSidebar
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
+                  />
+
+                  <div className="lg:col-span-2 space-y-6">
+                    <Routes>
+                      <Route path="/" element={<Home />} />
+                      <Route path="/messages" element={<Messages />} />
+                      <Route path="/profile" element={<Profile />} />
+                    </Routes>
+                  </div>
+
+                  <RightSidebar />
                 </div>
-                <RightSidebar />
               </div>
             </div>
-          </div>
-        } />
+          }
+        />
       </Routes>
     </Router>
   );

--- a/src/components/CurriculumBuilder.jsx
+++ b/src/components/CurriculumBuilder.jsx
@@ -1,0 +1,35 @@
+import { Reorder } from "framer-motion";
+import LessonItem from "./LessonItem";
+
+const CurriculumBuilder = ({ lessons, setLessons }) => {
+  const addLesson = () => {
+    setLessons([
+      ...lessons,
+      {
+        id: Date.now(),
+        title: `Lesson ${lessons.length + 1}`
+      }
+    ]);
+  };
+
+  return (
+    <div className="curriculum">
+      <h2>Curriculum Builder</h2>
+
+      <Reorder.Group
+        axis="y"
+        values={lessons}
+        onReorder={setLessons}
+        className="timeline"
+      >
+        {lessons.map((lesson) => (
+          <LessonItem key={lesson.id} lesson={lesson} />
+        ))}
+      </Reorder.Group>
+
+      <button onClick={addLesson}>➕ Add Lesson</button>
+    </div>
+  );
+};
+
+export default CurriculumBuilder;

--- a/src/components/DragDropUploader.jsx
+++ b/src/components/DragDropUploader.jsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+
+const DragDropUploader = () => {
+  const [active, setActive] = useState(false);
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setActive(false);
+
+    const files = Array.from(e.dataTransfer.files);
+    console.log("Uploaded files:", files);
+  };
+
+  return (
+    <div
+      className={`upload-zone ${active ? "active" : ""}`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        setActive(true);
+      }}
+      onDragLeave={() => setActive(false)}
+      onDrop={handleDrop}
+    >
+      <p>📤 Drag & Drop Videos or PDFs</p>
+      <span>Frontend only – upload handling later</span>
+    </div>
+  );
+};
+
+export default DragDropUploader;

--- a/src/components/LessonItem.jsx
+++ b/src/components/LessonItem.jsx
@@ -1,0 +1,16 @@
+import { Reorder } from "framer-motion";
+
+const LessonItem = ({ lesson }) => {
+  return (
+    <Reorder.Item
+      value={lesson}
+      className="lesson-item"
+      whileDrag={{ scale: 1.03 }}
+    >
+      <div className="lesson-dot" />
+      <span>{lesson.title}</span>
+    </Reorder.Item>
+  );
+};
+
+export default LessonItem;

--- a/src/components/LivePreview.jsx
+++ b/src/components/LivePreview.jsx
@@ -1,0 +1,32 @@
+import { motion } from "framer-motion";
+
+/**
+ * LivePreview Component
+ * Shows real-time preview of course title, description, and lessons
+ */
+const LivePreview = ({ title, description, lessons }) => {
+  return (
+    <div className="preview">
+      <h2>Live Preview</h2>
+
+      <motion.div
+        key={`${title}-${description}`}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ duration: 0.3 }}
+        className="preview-card"
+      >
+        <h3>{title || "Course Title"}</h3>
+        <p>{description || "Course description preview..."}</p>
+
+        <ul>
+          {lessons.map((l) => (
+            <li key={l.id}>{l.title}</li>
+          ))}
+        </ul>
+      </motion.div>
+    </div>
+  );
+};
+
+export default LivePreview;

--- a/src/pages/InstructorDashboard.jsx
+++ b/src/pages/InstructorDashboard.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import DragDropUploader from "../components/DragDropUploader";
+import CurriculumBuilder from "../components/CurriculumBuilder";
+import LivePreview from "../components/LivePreview";
+
+const InstructorDashboard = () => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [lessons, setLessons] = useState([]);
+
+  return (
+    <div className="dashboard">
+      <h1>Instructor Dashboard</h1>
+
+      <div className="course-form">
+        <input
+          type="text"
+          placeholder="Course Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <textarea
+          placeholder="Course Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+
+      <DragDropUploader />
+
+      <CurriculumBuilder lessons={lessons} setLessons={setLessons} />
+
+      <LivePreview
+        title={title}
+        description={description}
+        lessons={lessons}
+      />
+    </div>
+  );
+};
+
+export default InstructorDashboard;


### PR DESCRIPTION
Screenshot
<img width="947" height="897" alt="Screenshot 2026-01-09 111520" src="https://github.com/user-attachments/assets/7674c016-9168-47ca-a978-99b29f16100f" />

Description
Adds a frontend-only Instructor Dashboard & Course Creator layout with course inputs, curriculum management, and live preview.

PR Changes
Instructor Dashboard page (/instructor)
Drag-and-drop uploader UI (videos/PDFs)
Curriculum builder with reorder animation
Real-time live preview with fade-in effect

Related Issue
Fixes #101

Checklist
 Followed type(scope): subject commit format
 Tested on localhost:5173
 Ran npm run lint
 Responsive on desktop