### PR TITLE
feat: Implement useFocusTrap Hook for Modal Accessibility (Issue #391)

### DIFF
--- a/frontend/src/components/CommentModal.jsx
+++ b/frontend/src/components/CommentModal.jsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { commentsApi } from "../api/endpoints";
 import { useTheme } from "../context/ThemeContext";
+import useFocusTrap from "../hooks/useFocusTrap";
 
 const CommentModal = ({ isOpen, onClose, postId, commentCount }) => {
   const [comments, setComments] = useState([]);
   const [newComment, setNewComment] = useState("");
   const [loading, setLoading] = useState(false);
   const { theme } = useTheme();
+  const { modalRef } = useFocusTrap(isOpen, onClose);
 
   // This effect runs every time the postId changes, 
   // ensuring comments stay synced with the visible reel.
@@ -48,20 +50,23 @@ const CommentModal = ({ isOpen, onClose, postId, commentCount }) => {
   if (!isOpen) return null;
 
   return (
-    <div 
-      className={`fixed top-0 right-0 z-[1000] h-full w-full lg:w-[450px] shadow-2xl transition-transform duration-300 ease-in-out flex flex-col ${
-        isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-slate-900 text-white' : 'bg-white text-gray-900'}`}
+    <div
+      ref={modalRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      className={`fixed top-0 right-0 z-[1000] h-full w-full lg:w-[450px] shadow-2xl transition-transform duration-300 ease-in-out flex flex-col ${isOpen ? 'translate-x-0' : 'translate-x-full'
+        } ${theme === 'dark' ? 'bg-slate-900 text-white' : 'bg-white text-gray-900'}`}
     >
       {/* Header */}
       <div className="flex justify-between items-center p-6 border-b dark:border-slate-800 border-gray-100">
         <div>
-          <h3 className="text-xl font-bold">Comments</h3>
+          <h3 id="modal-title" className="text-xl font-bold">Comments</h3>
           <p className="text-sm text-gray-500">{commentCount} responses</p>
         </div>
         <button onClick={onClose} className="p-2 hover:bg-gray-100 dark:hover:bg-slate-800 rounded-full">
           <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
           </svg>
         </button>
       </div>
@@ -96,9 +101,8 @@ const CommentModal = ({ isOpen, onClose, postId, commentCount }) => {
             value={newComment}
             onChange={(e) => setNewComment(e.target.value)}
             placeholder="Write a comment..."
-            className={`w-full p-4 h-24 rounded-2xl resize-none outline-none border-none text-sm ${
-              theme === 'dark' ? 'bg-slate-800 text-white' : 'bg-gray-100 text-gray-900'
-            }`}
+            className={`w-full p-4 h-24 rounded-2xl resize-none outline-none border-none text-sm ${theme === 'dark' ? 'bg-slate-800 text-white' : 'bg-gray-100 text-gray-900'
+              }`}
           />
           <div className="flex justify-end">
             <button type="submit" disabled={!newComment.trim()} className="bg-purple-600 text-white px-8 py-2.5 rounded-full font-bold transition-all disabled:opacity-30">

--- a/frontend/src/hooks/useFocusTrap.js
+++ b/frontend/src/hooks/useFocusTrap.js
@@ -1,0 +1,124 @@
+/**
+ * useFocusTrap Hook
+ * Issue #391: Implement useFocusTrap Hook for Modal Accessibility
+ * 
+ * A custom hook to trap keyboard focus within a modal dialog,
+ * ensuring WCAG 2.1 compliance for accessible modal interactions.
+ */
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * useFocusTrap
+ * 
+ * @param {boolean} isOpen - Whether the modal is currently open
+ * @param {Function} onClose - Callback function to close the modal
+ * @returns {Object} { modalRef } - Ref to attach to the modal container
+ */
+const useFocusTrap = (isOpen, onClose) => {
+    const modalRef = useRef(null);
+    const previousActiveElement = useRef(null);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        // Store the element that had focus before modal opened
+        previousActiveElement.current = document.activeElement;
+
+        const modalElement = modalRef.current;
+        if (!modalElement) return;
+
+        // Get all focusable elements within the modal
+        const getFocusableElements = () => {
+            const focusableSelectors = [
+                'a[href]',
+                'button:not([disabled])',
+                'textarea:not([disabled])',
+                'input:not([disabled])',
+                'select:not([disabled])',
+                '[tabindex]:not([tabindex="-1"])'
+            ].join(', ');
+
+            return Array.from(modalElement.querySelectorAll(focusableSelectors));
+        };
+
+        // Focus the first focusable element when modal opens
+        const focusableElements = getFocusableElements();
+        if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+        }
+
+        // Handle Tab key to trap focus
+        const handleKeyDown = (e) => {
+            // Handle Escape key
+            if (e.key === 'Escape') {
+                onClose();
+                return;
+            }
+
+            // Handle Tab key
+            if (e.key === 'Tab') {
+                const focusableElements = getFocusableElements();
+
+                if (focusableElements.length === 0) {
+                    e.preventDefault();
+                    return;
+                }
+
+                const firstElement = focusableElements[0];
+                const lastElement = focusableElements[focusableElements.length - 1];
+
+                // Shift + Tab (backwards)
+                if (e.shiftKey) {
+                    if (document.activeElement === firstElement) {
+                        e.preventDefault();
+                        lastElement.focus();
+                    }
+                }
+                // Tab (forwards)
+                else {
+                    if (document.activeElement === lastElement) {
+                        e.preventDefault();
+                        firstElement.focus();
+                    }
+                }
+            }
+        };
+
+        // Add event listener
+        modalElement.addEventListener('keydown', handleKeyDown);
+
+        // Set aria-hidden on other content (optional but recommended)
+        const rootElement = document.getElementById('root');
+        if (rootElement) {
+            const children = Array.from(rootElement.children);
+            children.forEach(child => {
+                if (child !== modalElement && !modalElement.contains(child)) {
+                    child.setAttribute('aria-hidden', 'true');
+                }
+            });
+        }
+
+        // Cleanup
+        return () => {
+            modalElement.removeEventListener('keydown', handleKeyDown);
+
+            // Restore focus to the element that had it before modal opened
+            if (previousActiveElement.current && previousActiveElement.current.focus) {
+                previousActiveElement.current.focus();
+            }
+
+            // Remove aria-hidden from other content
+            if (rootElement) {
+                const children = Array.from(rootElement.children);
+                children.forEach(child => {
+                    child.removeAttribute('aria-hidden');
+                });
+            }
+        };
+    }, [isOpen, onClose]);
+
+    return { modalRef };
+};
+
+export default useFocusTrap;


### PR DESCRIPTION
- Created useFocusTrap custom hook for WCAG 2.1 compliance
- Implemented focus trapping with Tab/Shift+Tab cycling
- Added Escape key support to close modal
- Implemented focus restoration to trigger element
- Added ARIA attributes (role, aria-modal, aria-labelledby)
- Integrated hook into CommentModal component

Key Features Implemented:
useFocusTrap Hook (frontend/src/hooks/useFocusTrap.js):
Focus Trapping: Tab and Shift+Tab cycle through focusable elements within the modal only
Escape Key Support: Pressing Esc closes the modal
Focus Restoration: Returns focus to the element that opened the modal when it closes
ARIA Management: Sets aria-hidden="true" on background content while modal is open
Automatic Focus: Focuses the first focusable element when modal opens CommentModal.jsx

 Updates:
Integrated  useFocusTrap hook
Added ref={modalRef} to modal container
Added ARIA attributes:
role="dialog"
aria-modal="true"
aria-labelledby="modal-title"
Added id="modal-title" to the heading for proper labeling

WCAG 2.1 Compliance:
✅ Focus is trapped within the modal
✅ Keyboard navigation works properly
✅ Escape key closes the modal
✅ Focus returns to trigger element
✅ Proper ARIA attributes for screen readers

## ⚠️ Additional Notes
Add any additional context or information here.
