### PR TITLE
feat: replace footer abbreviations with social media icons

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,3 +1,5 @@
+import { FaGithub, FaLinkedin, FaInstagram, FaEnvelope } from "react-icons/fa";
+
 export default function Footer() {
   return (
     <footer>
@@ -9,14 +11,49 @@ export default function Footer() {
           </div>
 
           <div className="social-icons">
-            <a href="#" className="social-icon">GH</a>
-            <a href="#" className="social-icon">TW</a>
-            <a href="#" className="social-icon">LI</a>
-            <a href="#" className="social-icon">MA</a>
+            <a
+              href="https://github.com/abhishekkumar177/College_Media"
+              className="social-icon"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="GitHub"
+            >
+              <FaGithub />
+            </a>
+
+            <a
+              href="https://instagram.com/spydification"
+              className="social-icon"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+            >
+              <FaInstagram />
+            </a>
+
+            <a
+              href="https://www.linkedin.com/in/abhishek-kumar-771583288"
+              className="social-icon"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="LinkedIn"
+            >
+              <FaLinkedin />
+            </a>
+
+            <a
+              href="mailto:abhishekumar1772004@gmail.com"
+              className="social-icon"
+              aria-label="Email"
+            >
+              <FaEnvelope />
+            </a>
           </div>
         </div>
 
-        <div className="footer-bottom">&copy; 2026 ProjectX. All rights reserved.</div>
+        <div className="footer-bottom">
+          &copy; 2026 ProjectX. All rights reserved.
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
Replaced footer text abbreviations (GH, LI, MA) with proper social media icons.
Twitter was replaced with Instagram to match current social presence.

## Changes
- Added GitHub, Instagram, LinkedIn, and Mail icons
- Improved accessibility with aria-labels
- External links open in a new tab

## Screenshots
<img width="1901" height="217" alt="image" src="https://github.com/user-attachments/assets/58fa5d37-a0a8-4d0d-b034-0090f4f08415" />


Fixes #998
