### PR TITLE
Fix LICENSE filename to resolve README hyperlink

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+MIT License
+
+Copyright (c) 2026 Abhishekkumar177
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+


### PR DESCRIPTION
### **PR Description**

This PR renames `LICENSE.md` to `LICENSE` so that the LICENSE hyperlink in `README.md` resolves correctly.

**What changed**

* Renamed `LICENSE.md` → `LICENSE`

**Why**

* GitHub expects the license file to be named `LICENSE` (or similar standard names) for automatic detection and proper linking.
* The previous filename caused the README link to break.

**Impact**

* No functional code changes
* Improves documentation correctness and repository metadata detection